### PR TITLE
Add JSON Mode Support and improve docs

### DIFF
--- a/examples/json-mode/main.go
+++ b/examples/json-mode/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -55,10 +54,11 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Parse the response into a Product struct
+	// Create a JSON extractor without schema validation
+	extractor := deepseek.NewJSONExtractor(nil)
 	var product Product
-	if err := json.Unmarshal([]byte(resp.Choices[0].Message.Content), &product); err != nil {
-		log.Fatalf("Failed to parse JSON response: %v", err)
+	if err := extractor.ExtractJSON(resp, &product); err != nil {
+		log.Fatalf("Failed to extract JSON: %v", err)
 	}
 
 	// Print the formatted product information

--- a/json.go
+++ b/json.go
@@ -1,0 +1,227 @@
+package deepseek
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// JSONExtractor helps extract structured data from LLM responses
+type JSONExtractor struct {
+	// Optional JSON schema for validation
+	schema json.RawMessage
+}
+
+// NewJSONExtractor creates a new JSONExtractor instance
+func NewJSONExtractor(schema json.RawMessage) *JSONExtractor {
+	return &JSONExtractor{
+		schema: schema,
+	}
+}
+
+// ExtractJSON attempts to extract and parse JSON from an LLM response
+func (je *JSONExtractor) ExtractJSON(response *ChatCompletionResponse, target interface{}) error {
+	if response == nil {
+		return fmt.Errorf("response cannot be nil")
+	}
+
+	if len(response.Choices) == 0 {
+		return fmt.Errorf("no choices in response")
+	}
+
+	content := response.Choices[0].Message.Content
+	if content == "" {
+		return fmt.Errorf("empty content in response")
+	}
+
+	// Try to find JSON content with or without code blocks
+	jsonStr := je.extractJSONContent(content)
+	if jsonStr == "" {
+		return fmt.Errorf("no valid JSON content found in response")
+	}
+
+	// If schema is provided, validate the JSON against it
+	if je.schema != nil {
+		if err := je.validateJSON([]byte(jsonStr)); err != nil {
+			return fmt.Errorf("JSON validation failed: %w", err)
+		}
+	}
+
+	// Parse the JSON into the target structure
+	if err := json.Unmarshal([]byte(jsonStr), target); err != nil {
+		return fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	return nil
+}
+
+// validateJSON validates JSON content against the schema
+func (je *JSONExtractor) validateJSON(data []byte) error {
+	var schemaMap map[string]interface{}
+	if err := json.Unmarshal(je.schema, &schemaMap); err != nil {
+		return fmt.Errorf("invalid schema: %w", err)
+	}
+
+	var jsonData interface{}
+	if err := json.Unmarshal(data, &jsonData); err != nil {
+		return fmt.Errorf("invalid JSON data: %w", err)
+	}
+
+	// Basic type validation
+	if schemaType, ok := schemaMap["type"].(string); ok {
+		switch schemaType {
+		case "object":
+			if _, ok := jsonData.(map[string]interface{}); !ok {
+				return fmt.Errorf("expected object, got %T", jsonData)
+			}
+		case "array":
+			if _, ok := jsonData.([]interface{}); !ok {
+				return fmt.Errorf("expected array, got %T", jsonData)
+			}
+		}
+	}
+
+	return nil
+}
+
+// extractJSONContent attempts to extract valid JSON from the content
+func (je *JSONExtractor) extractJSONContent(content string) string {
+	content = strings.TrimSpace(content)
+
+	// First try to parse the entire content as JSON
+	if json.Valid([]byte(content)) {
+		return content
+	}
+
+	// Try to find JSON content in various formats
+	patterns := []struct {
+		extract func(string) string
+	}{
+		// Try code blocks first
+		{func(s string) string {
+			return je.extractBetween(s, "```json\n", "```")
+		}},
+		{func(s string) string {
+			return je.extractBetween(s, "```json", "```")
+		}},
+		{func(s string) string {
+			return je.extractBetween(s, "```\n", "```")
+		}},
+		{func(s string) string {
+			return je.extractBetween(s, "```", "```")
+		}},
+		// Then try to find JSON objects or arrays
+		{func(s string) string {
+			return je.findJSONInText(s)
+		}},
+	}
+
+	for _, pattern := range patterns {
+		if result := pattern.extract(content); result != "" {
+			return result
+		}
+	}
+
+	return ""
+}
+
+// extractBetween extracts content between start and end markers
+func (je *JSONExtractor) extractBetween(content, start, end string) string {
+	startIdx := strings.Index(content, start)
+	if startIdx == -1 {
+		return ""
+	}
+
+	content = content[startIdx+len(start):]
+	endIdx := strings.Index(content, end)
+	if endIdx == -1 {
+		return ""
+	}
+
+	result := strings.TrimSpace(content[:endIdx])
+	if json.Valid([]byte(result)) {
+		return result
+	}
+	return ""
+}
+
+// findJSONInText attempts to find valid JSON objects or arrays in text
+func (je *JSONExtractor) findJSONInText(content string) string {
+	// Find potential JSON start
+	var start, end int
+	var found bool
+
+	// Try to find JSON object
+	start = strings.Index(content, "{")
+	if start != -1 {
+		end = je.findMatchingBrace(content[start:])
+		if end != -1 {
+			found = true
+			end += start
+		}
+	}
+
+	// If no object found, try to find JSON array
+	if !found {
+		start = strings.Index(content, "[")
+		if start != -1 {
+			end = je.findMatchingBracket(content[start:])
+			if end != -1 {
+				found = true
+				end += start
+			}
+		}
+	}
+
+	if !found {
+		return ""
+	}
+
+	result := content[start : end+1]
+	if json.Valid([]byte(result)) {
+		return result
+	}
+	return ""
+}
+
+// findMatchingBrace finds the matching closing brace for a JSON object
+func (je *JSONExtractor) findMatchingBrace(content string) int {
+	if !strings.HasPrefix(content, "{") {
+		return -1
+	}
+
+	depth := 0
+	for i, char := range content {
+		switch char {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// findMatchingBracket finds the matching closing bracket for a JSON array
+func (je *JSONExtractor) findMatchingBracket(content string) int {
+	if !strings.HasPrefix(content, "[") {
+		return -1
+	}
+
+	depth := 0
+	for i, char := range content {
+		switch char {
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,209 @@
+package deepseek
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestJSONExtractor_ExtractJSON(t *testing.T) {
+	type Person struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+
+	tests := []struct {
+		name     string
+		response *ChatCompletionResponse
+		schema   json.RawMessage
+		want     Person
+		wantErr  bool
+	}{
+		{
+			name: "valid direct json",
+			response: &ChatCompletionResponse{
+				Choices: []Choice{
+					{
+						Message: Message{
+							Content: `{"name": "John", "age": 30}`,
+						},
+					},
+				},
+			},
+			want: Person{
+				Name: "John",
+				Age:  30,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid json in code block",
+			response: &ChatCompletionResponse{
+				Choices: []Choice{
+					{
+						Message: Message{
+							Content: "```json\n{\"name\": \"John\", \"age\": 30}\n```",
+						},
+					},
+				},
+			},
+			want: Person{
+				Name: "John",
+				Age:  30,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid json with schema validation",
+			response: &ChatCompletionResponse{
+				Choices: []Choice{
+					{
+						Message: Message{
+							Content: `{"name": "John", "age": 30}`,
+						},
+					},
+				},
+			},
+			schema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"name": {"type": "string"},
+					"age": {"type": "number"}
+				}
+			}`),
+			want: Person{
+				Name: "John",
+				Age:  30,
+			},
+			wantErr: false,
+		},
+		{
+			name:     "nil response",
+			response: nil,
+			wantErr:  true,
+		},
+		{
+			name: "empty choices",
+			response: &ChatCompletionResponse{
+				Choices: []Choice{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty content",
+			response: &ChatCompletionResponse{
+				Choices: []Choice{
+					{
+						Message: Message{
+							Content: "",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid json",
+			response: &ChatCompletionResponse{
+				Choices: []Choice{
+					{
+						Message: Message{
+							Content: "not a json",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid schema",
+			response: &ChatCompletionResponse{
+				Choices: []Choice{
+					{
+						Message: Message{
+							Content: `{"name": "John", "age": 30}`,
+						},
+					},
+				},
+			},
+			schema:  json.RawMessage(`invalid schema`),
+			wantErr: true,
+		},
+		{
+			name: "schema type mismatch",
+			response: &ChatCompletionResponse{
+				Choices: []Choice{
+					{
+						Message: Message{
+							Content: `{"name": "John", "age": 30}`,
+						},
+					},
+				},
+			},
+			schema:  json.RawMessage(`{"type": "array"}`),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			je := NewJSONExtractor(tt.schema)
+			var got Person
+			err := je.ExtractJSON(tt.response, &got)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExtractJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && (got != tt.want) {
+				t.Errorf("ExtractJSON() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJSONExtractor_extractJSONContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "direct json",
+			content: `{"name": "John"}`,
+			want:    `{"name": "John"}`,
+		},
+		{
+			name:    "json in code block with newlines",
+			content: "```json\n{\"name\": \"John\"}\n```",
+			want:    `{"name": "John"}`,
+		},
+		{
+			name:    "json in code block without newlines",
+			content: "```json{\"name\": \"John\"}```",
+			want:    `{"name": "John"}`,
+		},
+		{
+			name:    "json in generic code block",
+			content: "```\n{\"name\": \"John\"}\n```",
+			want:    `{"name": "John"}`,
+		},
+		{
+			name:    "json with surrounding text",
+			content: "Here is the JSON:\n{\"name\": \"John\"}",
+			want:    `{"name": "John"}`,
+		},
+		{
+			name:    "invalid json",
+			content: "not a json",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			je := NewJSONExtractor(nil)
+			if got := je.extractJSONContent(tt.content); got != tt.want {
+				t.Errorf("extractJSONContent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
FIxes 
#1
#2 

# Changes

## Added JSON Mode Support

* Implemented `JSONExtractor` to handle structured data extraction from LLM responses
* Added support for various JSON formats:
  * Direct JSON content
  * JSON within code blocks (```json)
  * JSON within regular code blocks (```)
  * JSON embedded in text
* Added optional schema validation for type safety
* Comprehensive test coverage for all JSON extraction scenarios

## Documentation Improvements

* Added JSON Mode documentation with examples
* Added schema validation examples
* Added table of contents to improve README navigation
* Organized documentation sections hierarchically

## Implementation Details

* New `json.go` file with `JSONExtractor` implementation
* New `json_test.go` with comprehensive test coverage
* Updated `examples/json-mode/main.go` with practical usage examples
* Added JSON mode section to README.md with code examples

## Testing

* Added test cases for:
  * Valid JSON extraction scenarios
  * Error handling
  * Schema validation
  * Various JSON formats
  * Edge cases

## Example Usage

```go
// Enable JSON mode in request
req := &deepseek.ChatCompletionRequest{
    Messages: messages,
    JSONMode: true,
}

// Extract JSON with optional schema validation
extractor := deepseek.NewJSONExtractor(schema)
var data MyStruct
if err := extractor.ExtractJSON(resp, &data); err != nil {
    log.Fatal(err)
}
```